### PR TITLE
Add a /v3/pointcode implementation

### DIFF
--- a/src/main/scala/com/socrata/geospace/lib/regioncache/SpatialIndex.scala
+++ b/src/main/scala/com/socrata/geospace/lib/regioncache/SpatialIndex.scala
@@ -108,22 +108,22 @@ object SpatialIndex {
   }
 
   /**
-   * Create a SpatialIndex[Int] from a Layer/FeatureSource.  The feature ID will be stored in the index.
+   * Create a SpatialIndex[String] from a Layer/FeatureSource.  The feature ID will be stored in the index.
    *
    * @param layer an org.geoscript.layer.Layer or GeoTools FeatureSource.
-   * @return a SpatialIndex[Int] where each entry is the geometry and ID from each feature
+   * @return a SpatialIndex[String] where each entry is the geometry and ID from each feature
    */
-  def apply(layer: Layer): SpatialIndex[Int] = apply(layer.features.toSeq)
+  def apply(layer: Layer): SpatialIndex[String] = apply(layer.features.toSeq)
 
   /**
-   * Create a SpatialIndex[Int] from a list of Features.  The feature ID will be stored in the index.
+   * Create a SpatialIndex[String] from a list of Features.  The feature ID will be stored in the index.
    *
    * @param features a sequence of Features
-   * @return a SpatialIndex[Int] where each entry is the geometry and ID from each feature
+   * @return a SpatialIndex[String] where each entry is the geometry and ID from each feature
    */
-  def apply(features: Seq[Feature]): SpatialIndex[Int] = {
+  def apply(features: Seq[Feature]): SpatialIndex[String] = {
     val items = features.map { feature =>
-      GeoEntry.compact(feature.getDefaultGeometry.asInstanceOf[Geometry], feature.numericId)
+      GeoEntry.compact(feature.getDefaultGeometry.asInstanceOf[Geometry], feature.getID)
     }
     new SpatialIndex(items.toSeq)
   }

--- a/src/main/scala/com/socrata/regioncoder/RegionCoderServlet.scala
+++ b/src/main/scala/com/socrata/regioncoder/RegionCoderServlet.scala
@@ -32,7 +32,7 @@ class RegionCoderServlet(rcConfig: RegionCoderConfig, val sodaFountain: SodaFoun
 
   get("/") {
     """{
-      |"hello": "region-coder why scala????"
+      |"hello": "region-coder"
     }""".stripMargin
   }
 

--- a/src/test/scala/com/socrata/geospace/lib/regioncache/SpatialRegionCacheSpec.scala
+++ b/src/test/scala/com/socrata/geospace/lib/regioncache/SpatialRegionCacheSpec.scala
@@ -11,13 +11,13 @@ class SpatialRegionCacheSpec extends FunSuiteLike with Matchers with RegionCache
     val entry = cache.getEntryFromFeatureJson(decodeFeatures(tenCompleteFeatures), "abcd-1234", "the_geom", "_feature_id")
     val pickOne = entry.firstContains(builder.Point(0,1))
     pickOne should be ('defined)
-    pickOne.get.item should be (1)
+    pickOne.get.item should be ("1")
   }
 
   test("getEntryFromFeatureJson - indexed on user_defined_key") {
     val entry = cache.getEntryFromFeatureJson(decodeFeatures(tenCompleteFeatures), "abcd-1234", "the_geom", "user_defined_key")
     val pickOne = entry.firstContains(builder.Point(0,1))
     pickOne should be ('defined)
-    pickOne.get.item should be (101)
+    pickOne.get.item should be ("101")
   }
 }


### PR DESCRIPTION
* DSAs need to be able to return values which are
  text
  * ex: return "countyName"
  * right now the valueToReturn always gets converted
    to an int, and fails if it can't be converted to
    an int
* This relaxes that requirement, but leaves the existing
  endpoint unchanged at /v2/pointcode, which continues
  to return ints