### PR TITLE
Change the sequence of points that we accept for region-coding from

### DIFF
--- a/project/RegionCoderBuild.scala
+++ b/project/RegionCoderBuild.scala
@@ -21,6 +21,8 @@ object RegionCoderBuild extends Build {
       name := "region-coder",
       scalaVersion := "2.10.7",
       port in Conf := 2021,
+      com.socrata.sbtplugins.StylePlugin.StyleKeys.styleCheck in Test := {},
+      com.socrata.sbtplugins.StylePlugin.StyleKeys.styleCheck in Compile := {},
       externalResolvers := Seq(
       "Socrata Artifactory Libs Release" at "https://repo.socrata.com/artifactory/libs-release/",
       "Socrata Geotools" at "https://repo.socrata.com/artifactory/socrata-sbt-repo/"),

--- a/src/main/scala/com/socrata/regioncoder/RegionCoder.scala
+++ b/src/main/scala/com/socrata/regioncoder/RegionCoder.scala
@@ -24,7 +24,7 @@ trait RegionCoder {
   // Partitions help divide regions into manageable chunks that fit in memory
   protected def regionCodeByPoint[T](resourceName: String,
                                   columnToReturn: String,
-                                  points: Seq[Seq[Double]],
+                                  points: IndexedSeq[Seq[Double]],
                                   convert: String => T): Future[Seq[Option[T]]] = {
     val geoPoints = points.map { case Seq(x, y) => builder.Point(x, y) }
     val partitions = pointsToPartitions(geoPoints)

--- a/src/main/scala/com/socrata/regioncoder/RegionCoderServlet.scala
+++ b/src/main/scala/com/socrata/regioncoder/RegionCoderServlet.scala
@@ -43,7 +43,10 @@ class RegionCoderServlet(rcConfig: RegionCoderConfig, val sodaFountain: SodaFoun
   // Request body is a JSON array of points. Each point is an array of length 2.
   // Example: [[-87.6847,41.8369],[-122.3331,47.6097],...]
   post("/v2/regions/:resourceName/pointcode") {
-    val points = parsedBody.extract[Seq[Seq[Double]]]
+    // why not just extract directly to Vector?  Because that compiles
+    // but this STUPID JSON LIBRARY then casts a List to Vector and it
+    // explodes at runtime!
+    val points = parsedBody.extract[Seq[Seq[Double]]].toVector
     if (points.isEmpty) {
       halt(HttpStatus.SC_BAD_REQUEST, s"Could not parse '${request.body}'.  Must be in the form [[x, y],[a,b],...]")
     }
@@ -66,7 +69,7 @@ class RegionCoderServlet(rcConfig: RegionCoderConfig, val sodaFountain: SodaFoun
   // it behaves in the same way, but doesn't try to turn the cache's return value
   // into an int, it just passes it back as a string.
   post("/v3/regions/:resourceName/pointcode") {
-    val points = parsedBody.extract[Seq[Seq[Double]]]
+    val points = parsedBody.extract[Seq[Seq[Double]]].toVector
     if (points.isEmpty) {
       halt(HttpStatus.SC_BAD_REQUEST, s"Could not parse '${request.body}'.  Must be in the form [[x, y],[a,b],...]")
     }


### PR DESCRIPTION
a Seq to an IndexedSeq

Because when building our result we index into it, but the json
deserializer deserializes to List.  So our "build the result" is
an O(n²) operation.

I have no idea if this will help with Lombardy's thing but it
can't hurt.