### PR TITLE
Rjm/fix concurrency

### DIFF
--- a/src/main/scala/com/socrata/geospace/lib/regioncache/LruCache.scala
+++ b/src/main/scala/com/socrata/geospace/lib/regioncache/LruCache.scala
@@ -3,8 +3,6 @@ package com.socrata.geospace.lib.regioncache
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.atomic.AtomicInteger
 import org.apache.commons.collections4.map.LRUMap
 
 class LruCache[K, V](maxEntries: Int) {

--- a/src/main/scala/com/socrata/geospace/lib/regioncache/LruCache.scala
+++ b/src/main/scala/com/socrata/geospace/lib/regioncache/LruCache.scala
@@ -1,19 +1,57 @@
 package com.socrata.geospace.lib.regioncache
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
 import org.apache.commons.collections4.map.LRUMap
 
 class LruCache[K, V](maxEntries: Int) {
+  private class Waiter {
+    var count = 1
+  }
+
   private val cache = new LRUMap[K, V](maxEntries)
+  private val waiters = new mutable.HashMap[K, Waiter]
 
   def apply(key: K)(f: => V): V = {
     Option(cache.synchronized { cache.get(key) }) match {
       case Some(value) =>
         value
+
       case None =>
-        val value: V = f
-        cache.synchronized(cache.put(key, value))
-        value
+        // it wasn't there; we'll want to compute it, but only if no
+        // one else is trying to compute it at the same time.  We'll
+        // create a lock-per-key to adjudicate that.
+        val waiter =
+          waiters.synchronized {
+            val w = waiters.getOrElseUpdate(key, new Waiter)
+            w.count += 1
+            w
+          }
+
+        try {
+          waiter.synchronized {
+            Option(cache.synchronized { cache.get(key) }) match {
+              case Some(value) =>
+                // someone else got there first
+                value
+
+              case None =>
+                // no one got there first, so finally we actually
+                // compute the value to cache.
+                val value: V = f
+                cache.synchronized { cache.put(key, value) }
+                value
+            }
+          }
+        } finally {
+          waiters.synchronized {
+            waiter.count -= 1
+            if(waiter.count == 0) waiters.remove(key)
+          }
+        }
     }
   }
 

--- a/src/main/scala/com/socrata/geospace/lib/regioncache/LruCache.scala
+++ b/src/main/scala/com/socrata/geospace/lib/regioncache/LruCache.scala
@@ -9,7 +9,7 @@ import org.apache.commons.collections4.map.LRUMap
 
 class LruCache[K, V](maxEntries: Int) {
   private class Waiter {
-    var count = 1
+    var count = 0
   }
 
   private val cache = new LRUMap[K, V](maxEntries)

--- a/src/main/scala/com/socrata/regioncoder/RegionCoder.scala
+++ b/src/main/scala/com/socrata/regioncoder/RegionCoder.scala
@@ -29,7 +29,7 @@ trait RegionCoder {
     val geoPoints = points.map { case (x, y) => builder.Point(x, y) }
     val partitions = pointsToPartitions(geoPoints)
 
-    val executor = new ThreadPoolExecutor(1, concurrencyPerJob, 1, TimeUnit.SECONDS, new LinkedBlockingQueue)
+    val executor = new ThreadPoolExecutor(concurrencyPerJob, concurrencyPerJob, 1, TimeUnit.SECONDS, new LinkedBlockingQueue)
     try {
       // Map unique partitions to SpatialIndices, fetching them in parallel using Futures
       // Now we have a Seq[Future[Envelope -> SpatialIndex]]


### PR DESCRIPTION
Two things here:
 * Make it so that if two threads both try to access an uncached key at the same time, only one of
   them will compute the value
 * Fix the thread pool so more than one thread gets created
