### PR TITLE
EN-52995: Upgrade SBT

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,14 @@
+import scala.sys.process.Process
+
 organization := "com.socrata"
 
 name := "region-coder"
 
 scalaVersion := "2.10.7"
 
-fork in Test := true
+Test / fork := true
+
+Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest)
 
 resolvers := Seq("Socrata Artifactory" at "https://repo.socrata.com/artifactory/libs-release/")
 
@@ -38,7 +42,8 @@ libraryDependencies ++= Seq(
 
   "com.socrata"              %% "socrata-thirdparty-test-utils" % "4.0.15" % "test",
   "com.socrata"              %% "socrata-curator-test-utils"    % "1.1.2" % "test",
-  "org.apache.curator"        % "curator-test"                  % "2.4.2" % "test"
+  "org.apache.curator"        % "curator-test"                  % "2.4.2" % "test",
+  "org.scalatest"            %% "scalatest"                     % "3.0.8" % "test"
 )
 
 def gitSha = Process(Seq("git", "describe", "--always", "--dirty", "--long", "--abbrev=10")).!!.stripLineEnd
@@ -61,6 +66,3 @@ buildInfoOptions += BuildInfoOption.ToMap
 releaseProcess := releaseProcess.value.filterNot(_ == ReleaseTransformations.publishArtifacts)
 
 enablePlugins(sbtbuildinfo.BuildInfoPlugin)
-
-com.socrata.sbtplugins.StylePlugin.StyleKeys.styleCheck in Test := {}
-com.socrata.sbtplugins.StylePlugin.StyleKeys.styleCheck in Compile := {}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=1.6.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,5 +11,6 @@ externalResolvers ++= Seq(
 addSbtPlugin("org.scalatra.sbt" % "sbt-scalatra"    % "1.0.4")
 addSbtPlugin("com.earldouglas"  % "xsbt-web-plugin" % "4.2.4")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.1.0")
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,7 +8,8 @@ externalResolvers ++= Seq(
   Resolver.url("Socrata Ivy Lib Releases", url("https://repo.socrata.com/artifactory/ivy-libs-release"))(Resolver.ivyStylePatterns)
 )
 
-addSbtPlugin("org.scalatra.sbt" % "scalatra-sbt"    % "0.4.0")
-addSbtPlugin("com.earldouglas"  % "xsbt-web-plugin" % "1.1.0")
-addSbtPlugin("com.socrata" % "socrata-sbt-plugins" % "1.6.8")
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.4.0")
+addSbtPlugin("org.scalatra.sbt" % "sbt-scalatra"    % "1.0.4")
+addSbtPlugin("com.earldouglas"  % "xsbt-web-plugin" % "4.2.4")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
+addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
+addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")

--- a/src/test/scala/com/socrata/geospace/lib/regioncache/SpatialIndexConcurrencySpec.scala
+++ b/src/test/scala/com/socrata/geospace/lib/regioncache/SpatialIndexConcurrencySpec.scala
@@ -2,14 +2,14 @@ package com.socrata.geospace.lib.regioncache
 
 import org.geoscript.geometry.{builder => build}
 import org.geoscript.layer._
-import org.scalatest.{FunSpec, ShouldMatchers}
+import org.scalatest.{FunSpec, Matchers}
 
 import scala.concurrent.Future
 
 /**
  * Tests that SpatialIndex can concurrently geocode/match polygons correctly, using Futures
  */
-class SpatialIndexConcurrencySpec extends FunSpec with ShouldMatchers {
+class SpatialIndexConcurrencySpec extends FunSpec with Matchers {
 
   val layer = Shapefile("data/chicago_wards/Wards.shp")
   val bbox = layer.getBounds

--- a/src/test/scala/com/socrata/geospace/lib/regioncache/SpatialIndexSpec.scala
+++ b/src/test/scala/com/socrata/geospace/lib/regioncache/SpatialIndexSpec.scala
@@ -1,10 +1,9 @@
 package com.socrata.geospace.lib.regioncache
 
-import org.scalatest.{FunSpec, OptionValues, ShouldMatchers}
+import org.scalatest.{FunSpec, OptionValues, Matchers}
 import org.geoscript.geometry.builder
-import org.scalatest.{FunSpec, ShouldMatchers}
 
-class SpatialIndexSpec extends FunSpec with ShouldMatchers with OptionValues {
+class SpatialIndexSpec extends FunSpec with Matchers with OptionValues {
   import SpatialIndex.{Entry, GeoEntry}
 
   val poly1 = builder.Polygon(Seq((10, 10), (10, 20), (20, 20), (20, 10), (10, 10)), Nil)

--- a/src/test/scala/com/socrata/regioncoder/RegionCoderServletSpec.scala
+++ b/src/test/scala/com/socrata/regioncoder/RegionCoderServletSpec.scala
@@ -1,5 +1,8 @@
 package com.socrata.regioncoder
 
+import org.scalatest._
+import org.scalatest.matchers._
+
 import java.io.ByteArrayInputStream
 import java.nio.charset.StandardCharsets
 import com.codahale.metrics.MetricRegistry
@@ -9,8 +12,6 @@ import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 import com.socrata.http.server.HttpRequest
 import com.rojoma.simplearm.v2._
 import com.rojoma.json.v3.interpolation._
-import org.scalatest.FunSuiteLike
-import org.scalatest.Matchers
 import com.socrata.http.common.AuxiliaryData
 import java.io.Closeable
 import com.socrata.geospace.lib.client.SodaResponse
@@ -24,7 +25,7 @@ object RegionCoderServletSpec {
 }
 
 // scalastyle:off multiple.string.literals
-class RegionCoderServletSpec extends FunSuiteLike with RegionCoderMockResponses with Matchers {
+class RegionCoderServletSpec extends FunSuite with RegionCoderMockResponses with Matchers {
   val metricRegistry = new MetricRegistry
 
   val cfg = new RegionCoderConfig(ConfigFactory.parseString(RegionCoderServletSpec.config).

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.25-SNAPSHOT"
+ThisBuild / version := "0.1.25-SNAPSHOT"


### PR DESCRIPTION
This upgrades the version of SBT used by region-coder. This removes the use of socrata-sbt-plugins, which seemed to be providing little value. Along w/ the SBT upgrade, this upgrades some of the other SBT plugins that are being used in this project, as well as the version of scalatest.

Did an e2e test in staging to ensure that region coding worked. The test consisted of importing a spatial lens, and importing a dataset with a georeference column, and then creating a map viz from that dataset aggregated based on neighborhood.

https://robo.test-socrata.com/dataset/Seattle-Pet-Escapes-By-Neighborhood/dv8z-rzdk