### PR TITLE
EN-77317: update pipelines version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,14 +1,16 @@
-@Library('socrata-pipeline-library@3.0.0') _
+@Library('socrata-pipeline-library@6.0.0') _
 
 commonPipeline(
-  defaultBuildWorker: 'build-worker',
   jobName: 'region-coder',
   language: 'scala',
-  languageVersion: '2.10',
   projects: [
     [
       name: 'region-coder',
+      compiled: true,
       deploymentEcosystem: 'marathon-mesos',
+      paths: [
+        dockerBuildContext: 'docker',
+      ],
       type: 'service'
     ]
   ],

--- a/build.sbt
+++ b/build.sbt
@@ -66,3 +66,5 @@ buildInfoOptions += BuildInfoOption.ToMap
 releaseProcess := releaseProcess.value.filterNot(_ == ReleaseTransformations.publishArtifacts)
 
 enablePlugins(sbtbuildinfo.BuildInfoPlugin)
+
+assembly/assemblyJarName := s"${name.value}-assembly.jar"


### PR DESCRIPTION
This commit updates the pipelines library version and makes the necessary changes to the parameters to adopt sbtWrappter instead of sbtBuild.